### PR TITLE
Correct way to locate special folders

### DIFF
--- a/Clean.py
+++ b/Clean.py
@@ -2,9 +2,10 @@ __author__ = "Remigius Kalimba"
 '''Add a timer so it does this automatically everyday at a set time'''
 
 
-from os import path, mkdir, listdir, rename
+from os import path, mkdir, listdir, rename, environ
 from getpass import getuser
 import time
+from sys import getwindowsversion
 
 class Project21():
     def __init__(self):
@@ -16,9 +17,17 @@ class Project21():
         '''
         user = getuser()
 
-        '''these two variables store their respective locations, lol like i had to explain that'''
-        self.desktopdir = 'C:\\Users\\'+user+'\\Desktop'
-        self.Alldesktopdir = 'C:\\Users\\Public\\Desktop'
+        # References:   https://en.wikipedia.org/wiki/Environment_variable#Default_values
+        #               https://en.wikipedia.org/wiki/Windows_NT#Releases
+        #
+        #
+        self.desktopdir = path.join(environ['USERPROFILE'],'Desktop')
+
+        # Determine Windows version; check if this is XP; accordingly, read target folders
+        if getwindowsversion().major < 6:
+            self.Alldesktopdir = path.join(environ['ALLUSERSPROFILE'],'Desktop')
+        else:
+            self.Alldesktopdir = path.join(environ['PUBLIC'],'Desktop')
 
         '''list of folders to be created'''
         self.folder_names = ["Folders", "Shortcuts", "Zips", "Executables", "Pictures", "Music", "Movies", "Docs", "Code"]


### PR DESCRIPTION
While original way of getting special folders will work in great deal of cases, if there is localized version of Windows or older one - it will fail. This is more standardized way to find out user and Public Desktop folders.