### PR TITLE
Add contributing section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ To activate it, run `source organise_desktop/bin/activate`
 Navigate to the repo and run the following command:
 `$ pip install -r requirements.txt`
 
-### Contributing
+# Contributing
 Please read the [Contributing Guidlines](https://github.com/blavejr/OrganiseDesktop/blob/master/CONTRIBUTING.md) for details about pull requests, bug reports or opening an issue. 

--- a/README.md
+++ b/README.md
@@ -44,3 +44,6 @@ To activate it, run `source organise_desktop/bin/activate`
 `$ git clone https://github.com/blavejr/OrganiseDesktop.git`
 Navigate to the repo and run the following command:
 `$ pip install -r requirements.txt`
+
+### Contributing
+Please read the [Contributing Guidlines](https://github.com/blavejr/OrganiseDesktop/blob/master/CONTRIBUTING.md) for details about pull requests, bug reports or opening an issue. 


### PR DESCRIPTION
Hello!

I thought the README.md file could benefit from having a link to the CONTRIBUTING.md page. Since most folks are looking at the README first, this will be helpful for users to easily get information they need with this link and makes the documentation as a whole more robust! The contributing guidelines will be straightforward and easy to access.

Thanks!