### PR TITLE
Fix Repeated Extension in JSON file

### DIFF
--- a/organise_desktop/Extension.json
+++ b/organise_desktop/Extension.json
@@ -144,7 +144,7 @@
 		".rem", ".rom", ".sav", ".t65", ".tec", ".tmp", ".toast", ".torrent", ".ttf", ".uue", ".vcd", ".xll", ".dtp", ".indd", ".mdi", ".p65", ".qxd", ".rels", 
 		".flipchart", ".odp", ".pps", ".ppsx", ".ppt", ".pptm", ".art", ".dcm", ".flif", ".heic", ".ithmb", ".mac", ".pct", ".pef", ".pgm", ".pict", ".plist", 
 		".pspimage", ".rwl", ".sfw", ".sr2", ".thm", ".wbmp", ".api", ".cdt", ".cfg", ".dun", ".fm3", ".gid", ".ht", ".icm", ".inf", ".prf", ".ods", ".wk3", 
-		".wks", ".xlr", ".xls", ".xlsb", ".xlsm", ".ani", ".bashrc", ".bash_history", ".bash_profile", ".bud", ".cab", ".cat", ".cpl", ".cur", ".deskthemepack", 
+		".wks", ".xlr", ".xlsb", ".xlsm", ".ani", ".bashrc", ".bash_history", ".bash_profile", ".bud", ".cab", ".cat", ".cpl", ".cur", ".deskthemepack", 
 		".dev", ".dit", ".dll", ".dmp", ".drv", ".dvd", ".ebd", ".ffl", ".ffo", ".fota", ".hiv", ".hlp", ".htt", ".icl", ".icns", ".iconpackage", ".ion", 
 		".iptheme", ".mlc", ".nb0", ".nt", ".pck", ".pnf", ".pol", ".prop", ".qvm", ".reg", ".sys", ".cvs", ".emz", ".mix", ".odg", ".pd", ".vsd", ".wmf", 
 		".wpg", ".dvsd", ".esp3", ".mepx", ".vproj", ".asp", ".aspx", ".cer", ".cfm", ".cfml", ".csr", ".do", ".htm", ".js", ".jsp", ".nzb", ".php", ".webloc", 


### PR DESCRIPTION
This should fix the bug where if the desktop had "xlsx" file and in organizer both Misc and Document options were selected , the program would not complete its process of organization and throw the following error :
"FileNotFoundError: [Errno 2] No such file or directory"