### PR TITLE
Simplify Cli Structure

### DIFF
--- a/organise_desktop/Cli.py
+++ b/organise_desktop/Cli.py
@@ -4,6 +4,7 @@ from cronController import schedule_start, schedule_end
 import os
 import sys
 import json
+import click
 
 pwd = os.path.dirname(os.path.abspath(__file__))
 
@@ -11,80 +12,72 @@ Extensions = json.load(open(pwd+'/Extension.json'))
 
 folders = [x for x in Extensions]
 
-def print_usage():
+@click.command()
+@click.option(
+    "--undosched",
+    "-u",
+    is_flag=True,
+    help="Undo changes that were made.",
+)
+@click.option(
+    "--sched",
+    "-s",
+    is_flag=True,
+    help="Schedule an organization process to run."
+)
+@click.option(
+    "--desched",
+    "-d",
+    is_flag=True,
+    help="Remove a scheduled organization process."
+)
+@click.option(
+    "--ignore",
+    "-i",
+    type=str,
+    multiple=True,
+    help="Identify which file extension to exclude from organization. This should be passed for each file extension."
+)
+def cli(
+    undosched,
+    sched,
+    desched,
+    ignore
+):
     """
-        Prints usage of the Command Line interface
+    This is used to call a command line interface.
     """
-    print("Usage: " + sys.argv[0] + " <argument>")
-    print("-h                                 -- Display help message.")
-    print("-u                                 -- Undo")
-    print("-c --all                           -- Clean. If given --all then cleans all otherwise prompts")
-    print("-s --r                             -- start a schedule. removes a schedule if --r given")
-
-if __name__ == '__main__':
-    
-    if len(sys.argv) <= 1:
-        print_usage()
-
-    elif sys.argv[1] == '-h':
-        print_usage()
-
-    elif sys.argv[1] == '-u':
+    if undosched:
         undo()
-        sys.exit()
 
-    elif sys.argv[1] == '-c':
-        
-        if len(sys.argv) == 3:
-            
-            if sys.argv[2] == '--all':
-                organise_desktop(Extensions)
-                sys.exit()
-                
-            else:
-                print("Invalid input")
-                sys.exit()    
-            
-        elif len(sys.argv) == 2:
-            for x in enumerate(folders):
-                print('{} - {}'.format(x[0], x[1]))
-                
-            try:    
-                exclude = input("Enter indexes of types to EXCLUDE\nEnter multiple by separating by a ,:\n")
-            except KeyboardInterrupt:
-                sys.exit()
+    elif sched:
+        schedule_start(folders)
 
-            exclude_list = [int(i) for i in exclude.split(',')]
-            to_clean = {}
-            
-            for i in range(len(folders)):
-                if i not in exclude_list:
-                    to_clean[folders[i]] = Extensions[folders[i]]
-                    
-                    
-            organise_desktop(to_clean)
-            
-            sys.exit()
-        
-        else:
-            print("Invalid Input")
-            sys.exit()
+    elif desched:
+        schedule_end()
 
-    elif sys.argv[1] == "-s":
-        
-        if len(sys.argv) == 2:
-            print("Starting schedule..")
-            schedule_start(folders)
-            
-        elif sys.argv[2] == '--r':
-            print("Removing schedule..")
-            schedule_end()
-            
-        else:
-            print("Invalid Input")
-            sys.exit()    
+    elif ignore:
+
+        tmp_ext_list = []
+        for i in ignore: # Create a tuple with all the given extensions
+            tmp_ext_list.extend(i.split(','))
+
+        extension_tuple = tuple([ # add periods to the start of extensions if not already there
+            x if x[0] == '.' else f".{x}" for x in tmp_ext_list
+        ])
+
+        to_clean = { # create a dict that doesn't include the provided extensions, based on the extensions in the json file
+            category: [
+                extension for extension in Extensions[category] if extension not in extension_tuple
+            ] for category in Extensions
+        }
+
+        organise_desktop(to_clean)
 
     else:
-        print("Invalid Input")
-        sys.exit()            
-        
+        organise_desktop(Extensions)
+
+    sys.exit()
+
+if __name__ == '__main__':
+    cli()

--- a/organise_desktop/Cli.py
+++ b/organise_desktop/Cli.py
@@ -14,7 +14,7 @@ folders = [x for x in Extensions]
 
 @click.command()
 @click.option(
-    "--undosched",
+    "--undosort",
     "-u",
     is_flag=True,
     help="Undo changes that were made.",
@@ -47,7 +47,7 @@ def cli(
     """
     This is used to call a command line interface.
     """
-    if undosched:
+    if undosort:
         undo()
 
     elif sched:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests==2.18.4
 six==1.11.0
 urllib3==1.22
 urwid==2.0.1
+Click>=7.0


### PR DESCRIPTION
This change removes the need to parse arguments from sys.argv by using Click in order to handle the command line arguments. The flags that can be used have been modified a bit to support this change.

- --ignore/-i       This is used to identify which file extensions to ignore when sorting.
- --sched/-s      This is used to schedule sorting.
- --desched/-d  This is used to deschedule sorting.
- --undosort/-u  This is used to undo a sort.
- -h                   This is used to display the different command line arguments available and usage.

One notable change to usage is that the extensions to ignore during sorting can be passed with or without the preceding period, multiple --ignore/-i flags can be used to pass multiple extensions (a comma delimited string of extensions can still be passed), and the parsing of extensions is handled in a more pythonic way.